### PR TITLE
RDKEVL-6469: Upgrade OSS 4.7.4-community version in vendor layer.

### DIFF
--- a/rdke-raspberrypi.xml
+++ b/rdke-raspberrypi.xml
@@ -23,7 +23,7 @@
     <project groups="layers" name="meta-oss-reference-release" path="rdke/common/meta-oss-reference-release" remote="rdkcentral" revision="refs/tags/4.7.4-community">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_OSS_RELEASE"/>
     </project>
-    <project groups="layers" name="meta-rdk-oss-reference" path="rdke/common/meta-rdk-oss-reference" remote="rdkcentral" revision="refs/tags/4.7.1">
+    <project groups="layers" name="meta-rdk-oss-reference" path="rdke/common/meta-rdk-oss-reference" remote="rdkcentral" revision="refs/tags/4.7.4-community">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_COMMON_OSS_REFERENCE"/>
     </project>
     <project groups="extention" name="meta-oss-common-config" path="rdke/configs/ext" remote="rdkcentral" revision="refs/tags/1.1.0">


### PR DESCRIPTION
Reason for change: Upgrade OSS 4.7.4-community version in vendor layer.
Test Procedure: Build and verify
Risks: High.
Signed-off-by: sundaramuneeswaran_muthuraj@comcast.com