### PR TITLE
RDKMVE-1795 : Upgrade meta-rdk-halif-headers to Version 4.1.4.

### DIFF
--- a/rdke-raspberrypi.xml
+++ b/rdke-raspberrypi.xml
@@ -9,11 +9,11 @@
     </project>
 
     <!-- Common submanifest -->
-    <submanifest name="common" project="rdke-generic-manifest" manifest-name="rdke-common-layers.xml" path="rdke/common" remote="rdkcentral" revision="develop">
+    <submanifest name="common" project="rdke-generic-manifest" manifest-name="rdke-common-layers.xml" path="rdke/common" remote="rdkcentral" revision="feature/RDKMVE-1795-halif-update-4.1.4">
     </submanifest>
 
     <!-- configs submanifest -->
-    <submanifest name="configs" project="rdke-generic-manifest" manifest-name="rdke-configs-layers.xml" path="rdke/configs" remote="rdkcentral" revision="develop">
+    <submanifest name="configs" project="rdke-generic-manifest" manifest-name="rdke-configs-layers.xml" path="rdke/configs" remote="rdkcentral" revision="feature/RDKMVE-1795-halif-update-4.1.4">
     </submanifest>
 
     <!-- Product layer -->


### PR DESCRIPTION
**Reason for change:** Upgrade meta-rdk-halif-headers to Version 4.1.4.
**Test Procedure:** build and verify.
**Risks:** High.
**Signed-off-by:** sundaramuneeswaran_muthuraj@comcast.com