### PR TITLE
RDKEVL-6491 - Auto PR for rdkcentral/meta-vendor-raspberrypi-dev 354

### DIFF
--- a/rdke-raspberrypi.xml
+++ b/rdke-raspberrypi.xml
@@ -26,7 +26,7 @@
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_OSS_VENDOR" />
     </project>
     
-    <project groups="layers" name="meta-vendor-raspberrypi-dev" path="rdke/vendor/meta-vendor-raspberrypi-dev" remote="rdkcentral" revision="edfcc491a962c489a800eb52d876f4085c30d509">
+    <project groups="layers" name="meta-vendor-raspberrypi-dev" path="rdke/vendor/meta-vendor-raspberrypi-dev" remote="rdkcentral" revision="d64fa90dd85206ab8d3e77bfda31c66e741930c3">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_PLATFORM" />
         <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
     </project>


### PR DESCRIPTION
Details: Reason for change:  westeros refactoring where westeros is split into 5 different repositories

Test Procedure: Build and verify

Risks: Low


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-vendor-raspberrypi-dev, Merge Commit SHA: d64fa90dd85206ab8d3e77bfda31c66e741930c3
