### PR TITLE
RDKEVL-6491 - Auto PR for rdkcentral/meta-oss-vendor-raspberrypi 81

### DIFF
--- a/rdke-raspberrypi.xml
+++ b/rdke-raspberrypi.xml
@@ -22,7 +22,7 @@
     </project>
     
     
-    <project groups="products" name="meta-oss-vendor-raspberrypi" path="rdke/vendor/meta-vendor-raspberrypi-oss" remote="rdkcentral" revision="d1b5ff65dc9f2afa8c8ae71587483aeabd5e36ab">
+    <project groups="products" name="meta-oss-vendor-raspberrypi" path="rdke/vendor/meta-vendor-raspberrypi-oss" remote="rdkcentral" revision="bbe88d2269d1ff03bc3ad9df76aefe53c486cf1a">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_OSS_VENDOR" />
     </project>
     


### PR DESCRIPTION
Details: Reason for change:  westeros refactoring where westeros is split into 5 different repositories

Test Procedure: Build and verify

Risks: Low


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-oss-vendor-raspberrypi, Merge Commit SHA: bbe88d2269d1ff03bc3ad9df76aefe53c486cf1a
