### PR TITLE
REFPLTV-3098 - Auto PR for rdkcentral/meta-oss-vendor-raspberrypi 82

### DIFF
--- a/rdke-raspberrypi.xml
+++ b/rdke-raspberrypi.xml
@@ -22,7 +22,7 @@
     </project>
     
     
-    <project groups="products" name="meta-oss-vendor-raspberrypi" path="rdke/vendor/meta-vendor-raspberrypi-oss" remote="rdkcentral" revision="a373ed104ea83b7c82fee63d6e62367ea1b26bee">
+    <project groups="products" name="meta-oss-vendor-raspberrypi" path="rdke/vendor/meta-vendor-raspberrypi-oss" remote="rdkcentral" revision="c32a04b662607fc86d67bb698cfc3ea1a57d77e3">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_OSS_VENDOR" />
     </project>
     


### PR DESCRIPTION
Details: Reason for change: Added the -DFlag WESTEROS_PLATFORM_EMBEDDED_RPI for App slowness issue fix.
Test Procedure: Build and verify.
Risks: High.
Signed-off-by: sundaramuneeswaran_muthuraj@comcast.com


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-oss-vendor-raspberrypi, Merge Commit SHA: c32a04b662607fc86d67bb698cfc3ea1a57d77e3
