### PR TITLE
RDKMVE-2612:OSS and common metalayers update to 4.13.0

### DIFF
--- a/rdke-raspberrypi.xml
+++ b/rdke-raspberrypi.xml
@@ -9,7 +9,7 @@
     </project>
 
     
-    <submanifest name="common" project="rdke-generic-manifest" manifest-name="rdke-common-layers.xml" path="rdke/common" remote="rdkcentral" revision="refs/tags/1.0.2">
+    <submanifest name="common" project="rdke-generic-manifest" manifest-name="rdke-common-layers.xml" path="rdke/common" remote="rdkcentral" revision="feature/RDKMVE-2612">
     </submanifest>
 
     


### PR DESCRIPTION
Reason for change : Update oss and common layer to 5.13.0
Test Procedure : Build and test
Priority : Unprioritized
Risks : None