### PR TITLE
RDKMVE-2589 - Auto PR for rdkcentral/meta-vendor-raspberrypi-dev 372

### DIFF
--- a/rdke-raspberrypi.xml
+++ b/rdke-raspberrypi.xml
@@ -26,7 +26,7 @@
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_OSS_VENDOR" />
     </project>
     
-    <project groups="layers" name="meta-vendor-raspberrypi-dev" path="rdke/vendor/meta-vendor-raspberrypi-dev" remote="rdkcentral" revision="8250f6d96117c0ce2b878a043fdd1bed9ea23242">
+    <project groups="layers" name="meta-vendor-raspberrypi-dev" path="rdke/vendor/meta-vendor-raspberrypi-dev" remote="rdkcentral" revision="35131d8df3e7163e06b3f23eac74629d613d6fd9">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_PLATFORM" />
         <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
     </project>


### PR DESCRIPTION
Details: Reason for change: Move RCU Keymap configuration to vendor layer
Test Procedure : Build is successful
Priority : Unprioritized
Risks : None


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-vendor-raspberrypi-dev, Merge Commit SHA: 35131d8df3e7163e06b3f23eac74629d613d6fd9
