### PR TITLE
RDKEVL-7501 - Auto PR for rdkcentral/meta-vendor-raspberrypi-dev 381

### DIFF
--- a/rdke-raspberrypi.xml
+++ b/rdke-raspberrypi.xml
@@ -26,7 +26,7 @@
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_OSS_VENDOR" />
     </project>
     
-    <project groups="layers" name="meta-vendor-raspberrypi-dev" path="rdke/vendor/meta-vendor-raspberrypi-dev" remote="rdkcentral" revision="19193ddd69c397f46970d14ab123af4dbe258f24">
+    <project groups="layers" name="meta-vendor-raspberrypi-dev" path="rdke/vendor/meta-vendor-raspberrypi-dev" remote="rdkcentral" revision="ac1e545b8456869bfdf38d4598167689786a7d75">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_PLATFORM" />
         <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
     </project>


### PR DESCRIPTION
Details: Reason: Includes fix for Primary/Secondary Language VTS failures.


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-vendor-raspberrypi-dev, Merge Commit SHA: ac1e545b8456869bfdf38d4598167689786a7d75
