### PR TITLE
RDKMVE-3086 - Auto PR for rdkcentral/meta-oss-vendor-raspberrypi 90

### DIFF
--- a/rdke-raspberrypi.xml
+++ b/rdke-raspberrypi.xml
@@ -22,7 +22,7 @@
     </project>
     
     
-    <project groups="products" name="meta-oss-vendor-raspberrypi" path="rdke/vendor/meta-vendor-raspberrypi-oss" remote="rdkcentral" revision="refs/tags/4.1.7">
+    <project groups="products" name="meta-oss-vendor-raspberrypi" path="rdke/vendor/meta-vendor-raspberrypi-oss" remote="rdkcentral" revision="a6c2e2752f49485b010e75ec5f5726d7c964b9bd">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_OSS_VENDOR" />
     </project>
     


### PR DESCRIPTION
Details: Reason for change:  OSS release 4.14.0 has westeros refactoring changes incorporated,We need to use that in community builds and move to new westeros repos hosted in github.

Test Procedure: Build and verify

Risks: Low


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-oss-vendor-raspberrypi, Merge Commit SHA: a6c2e2752f49485b010e75ec5f5726d7c964b9bd
