### PR TITLE
RDKMVE-2996 - Auto PR for rdkcentral/meta-vendor-raspberrypi-dev 383

### DIFF
--- a/rdke-raspberrypi.xml
+++ b/rdke-raspberrypi.xml
@@ -26,7 +26,7 @@
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_OSS_VENDOR" />
     </project>
     
-    <project groups="layers" name="meta-vendor-raspberrypi-dev" path="rdke/vendor/meta-vendor-raspberrypi-dev" remote="rdkcentral" revision="b30f1354f3717f403a3772e14b1fc19cba0acc39">
+    <project groups="layers" name="meta-vendor-raspberrypi-dev" path="rdke/vendor/meta-vendor-raspberrypi-dev" remote="rdkcentral" revision="b6eb471a63028d049a7ae69737b1f0df4b2bc59f">
         <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_PLATFORM" />
         <annotation name="MANIFEST_EXPORT_PATH1" value="MANIFEST_PATH_BBLAYERS_TEMPLATE" />
     </project>


### PR DESCRIPTION
Details: Reason for change : Update oss and common layer to 4.14.0
Test Procedure : Build and test
Priority : Unprioritized
Risks : None


List of PRs and Repositories Involved:
- Repository: rdkcentral/meta-vendor-raspberrypi-dev, Merge Commit SHA: b6eb471a63028d049a7ae69737b1f0df4b2bc59f
